### PR TITLE
Use expand instead of context

### DIFF
--- a/src/components/employees/Employee.css
+++ b/src/components/employees/Employee.css
@@ -1,0 +1,11 @@
+.employees {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.employee {
+  margin: 1rem;
+  padding: 1rem;
+  border: dashed blue 2px;
+  width: 12rem;
+}

--- a/src/components/employees/Employee.js
+++ b/src/components/employees/Employee.js
@@ -1,11 +1,11 @@
 import React from "react"
 import "./Employee.css"
 
-export const Employee = ({employee, location}) => {
+export const Employee = ({employee}) => {
   return (
     <div className="employee" >
       <div className="employee__name">Name: {employee.name}</div>
-      <div className="employee__location">Location: {location.address}</div>
+      <div className="employee__location">Location: {employee.location.address}</div>
       <div className="employee__isManager">Manager: {employee.isManager}</div>
       <div className="employee__isFullTime">Full Time:{employee.isFullTime}</div>
       <div className="employee__hourlyRate">Hourly Rate: {employee.hourlyRate}</div>

--- a/src/components/employees/Employee.js
+++ b/src/components/employees/Employee.js
@@ -1,7 +1,14 @@
 import React from "react"
+import "./Employee.css"
 
-export const Employee = ({employee}) => {
+export const Employee = ({employee, location}) => {
   return (
-    <div className="employee__name">{employee.name}</div>
+    <div className="employee" >
+      <div className="employee__name">Name: {employee.name}</div>
+      <div className="employee__location">Location: {location.address}</div>
+      <div className="employee__isManager">Manager: {employee.isManager}</div>
+      <div className="employee__isFullTime">Full Time:{employee.isFullTime}</div>
+      <div className="employee__hourlyRate">Hourly Rate: {employee.hourlyRate}</div>
+    </div>
   )
 }

--- a/src/components/employees/EmployeeList.js
+++ b/src/components/employees/EmployeeList.js
@@ -5,12 +5,10 @@ import { LocationContext } from "../locations/LocationProvider"
 
 export const EmployeeList = (props) => {
   const { employees, getEmployees } = useContext(EmployeeContext)
-  const { locations, getLocations } = useContext(LocationContext)
 
 
   useEffect( () => {
     getEmployees()
-    getLocations()
   }, [])
 
   return (
@@ -20,10 +18,7 @@ export const EmployeeList = (props) => {
       </button>
       <div className="employees">
         {
-          employees.map( e => {
-            const location = locations.find(location => e.locationId === location.id) || {}
-            return <Employee key={e.id} employee={e} location={location}/>
-        })
+          employees.map( e => <Employee key={e.id} employee={e} />)
         }
       </div>
     </>

--- a/src/components/employees/EmployeeList.js
+++ b/src/components/employees/EmployeeList.js
@@ -1,13 +1,16 @@
 import React, { useContext, useEffect } from "react"
 import { EmployeeContext } from "./EmployeeProvider"
 import { Employee } from "./Employee"
+import { LocationContext } from "../locations/LocationProvider"
 
 export const EmployeeList = (props) => {
   const { employees, getEmployees } = useContext(EmployeeContext)
+  const { locations, getLocations } = useContext(LocationContext)
 
 
   useEffect( () => {
     getEmployees()
+    getLocations()
   }, [])
 
   return (
@@ -17,7 +20,10 @@ export const EmployeeList = (props) => {
       </button>
       <div className="employees">
         {
-          employees.map( e => <Employee key={e.id} employee={e}/>)
+          employees.map( e => {
+            const location = locations.find(location => e.locationId === location.id) || {}
+            return <Employee key={e.id} employee={e} location={location}/>
+        })
         }
       </div>
     </>

--- a/src/components/employees/EmployeeProvider.js
+++ b/src/components/employees/EmployeeProvider.js
@@ -6,7 +6,7 @@ export const EmployeeProvider = (props) => {
   const [ employees, setEmployees ] = useState([])
 
   const getEmployees = () => {
-    return fetch("http://localhost:8088/employees")
+    return fetch("http://localhost:8088/employees?_expand=location")
       .then( res => res.json())  
       .then(setEmployees)
   }


### PR DESCRIPTION
Learning exercise: refactored to use the json-server expand syntax, instead of using hooks to get the context of locations when displaying the employee cards.